### PR TITLE
docs: update license headers and add governance model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
+<!--
+SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+
+SPDX-License-Identifier: 0BSD
+-->
+
 ## [1.1.0](https://github.com/AliSajid/charx/compare/v1.0.2...v1.1.0) (2024-09-02)
 
 ### Features
 
-* performance imrpvoments with testing ([5115f74](https://github.com/AliSajid/charx/commit/5115f7413b2a9bcd6aa1f715f8595416c71e1a4f))
+- performance improvements with testing ([5115f74](https://github.com/AliSajid/charx/commit/5115f7413b2a9bcd6aa1f715f8595416c71e1a4f))
 
 ### Bug Fixes
 
-* add must_use and const attributes to functions for optimization ([76eb83c](https://github.com/AliSajid/charx/commit/76eb83caf38a34c9dbe9b961264f55cd99592e14))
+- add `must_use` and `const` attributes to functions for optimization ([76eb83c](https://github.com/AliSajid/charx/commit/76eb83caf38a34c9dbe9b961264f55cd99592e14))
 
 ## [1.1.0-next.1](https://github.com/AliSajid/charx/compare/v1.0.2...v1.1.0-next.1) (2024-09-02)
 
 ### Features
 
-* performance imrpvoments with testing ([d7b8916](https://github.com/AliSajid/charx/commit/d7b89160a2c203e5b58449516daf1a638c044ea4))
+- performance improvements with testing ([d7b8916](https://github.com/AliSajid/charx/commit/d7b89160a2c203e5b58449516daf1a638c044ea4))
 
 ### Bug Fixes
 
-* add must_use and const attributes to functions for optimization ([451cbbf](https://github.com/AliSajid/charx/commit/451cbbfd5e10b5a092f8022bc355971ff2d25682))
+- add `must_use` and `const` attributes to functions for optimization ([451cbbf](https://github.com/AliSajid/charx/commit/451cbbfd5e10b5a092f8022bc355971ff2d25682))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
 
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: 0BSD
 -->
 
 # Contributor Covenant Code of Conduct
@@ -23,23 +23,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
 
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: 0BSD
 -->
 
 <!-- omit in toc -->

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,42 @@
+<!--
+SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+
+SPDX-License-Identifier: 0BSD
+-->
+
+# Project Governance Model
+
+## Overview
+
+This document outlines how decisions are made for this project, defines the roles of contributors, and establishes how conflicts are resolved.
+
+## Roles and Responsibilities
+
+### Project Owner
+
+The Project Owner currently makes all final decisions on the project's direction, design, and functionality. This role is responsible for:
+
+- Approving or rejecting contributions (such as pull requests)
+- Setting the project roadmap and priorities
+- Managing project releases
+- Resolving disputes or conflicting opinions
+
+### Contributors
+
+Contributors are anyone who submits code, documentation, or other changes to the project. Contributions are made via pull requests and are subject to review by the Project Owner. Contributors:
+
+- Suggest improvements to the project
+- Participate in discussions and feedback sessions
+- Submit code, documentation, or bug reports
+
+## Decision-Making Process
+
+Decisions are currently made by the Project Owner based on project needs, feedback from contributors, and long-term project vision. As the project grows, decision-making may evolve to include more collaborative processes.
+
+## Conflict Resolution
+
+If disagreements arise, the Project Owner will have the final say. The Project Owner will take into account all feedback and suggestions before making a decision.
+
+## Future Governance Changes
+
+As the project grows and gains more contributors, the governance model may shift to include a more formal process, such as meritocracy or group maintainers, to better accommodate additional contributors. Any changes to this governance structure will be reflected in this document.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Soni L.
 SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2024 Soni L.
 
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: 0BSD
 -->
 
 # A replacement for char


### PR DESCRIPTION
### TL;DR
Added project governance documentation and updated license headers across documentation files.

### What changed?
- Added new `GOVERNANCE.md` file outlining project roles, decision-making processes, and conflict resolution
- Updated license headers from `CC0-1.0` to `0BSD` in documentation files
- Fixed formatting and markdown styling in `CHANGELOG.md` and `CODE_OF_CONDUCT.md`
- Reordered copyright text in `README.md`

### How to test?
1. Review the new `GOVERNANCE.md` file for completeness and clarity
2. Verify license headers are consistently using `0BSD` in all documentation files
3. Ensure markdown formatting renders correctly in GitHub's interface

### Why make this change?
To establish clear project governance guidelines and maintain consistent licensing across the project documentation. This change helps contributors understand project structure, decision-making processes, and their roles within the project.