### PR TITLE
docs: add the OSS Lifecycle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ SPDX-License-Identifier: 0BSD
 ![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/charx)
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/alisajid/charx/latest)
 ![GitHub Created At](https://img.shields.io/github/created-at/AliSajid/charx)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9684/badge)](https://www.bestpractices.dev/projects/9684)
+![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: 0BSD
 ![Crates.io](https://img.shields.io/crates/l/charx)
 [![REUSE status](https://api.reuse.software/badge/github.com/AliSajid/brainfoamkit)](https://api.reuse.software/info/github.com/AliSajid/brainfoamkit)
 ![Codecov](https://img.shields.io/codecov/c/github/AliSajid/charx)
+![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fgithub.com%2FAliSajid%2Fcharx%2Fblob%2Fmain%2FOSSMETADATA)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ SPDX-License-Identifier: 0BSD
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/alisajid/charx/latest)
 ![GitHub Created At](https://img.shields.io/github/created-at/AliSajid/charx)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9684/badge)](https://www.bestpractices.dev/projects/9684)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/293d6f6e3e5e4fadb1b88db426462f87)](https://app.codacy.com/gh/AliSajid/charx/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/AliSajid/charx)
 ![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ SPDX-License-Identifier: 0BSD
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/293d6f6e3e5e4fadb1b88db426462f87)](https://app.codacy.com/gh/AliSajid/charx/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 ![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/AliSajid/charx)
 ![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)
+[![docs.rs](https://img.shields.io/docsrs/charx)](https://docs.rs/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: 0BSD
 ![Codecov](https://img.shields.io/codecov/c/github/AliSajid/charx)
 ![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fgithub.com%2FAliSajid%2Fcharx%2Fblob%2Fmain%2FOSSMETADATA)
 ![Crates.io MSRV](https://img.shields.io/crates/msrv/charx)
+![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SPDX-License-Identifier: 0BSD
 [![REUSE status](https://api.reuse.software/badge/github.com/AliSajid/brainfoamkit)](https://api.reuse.software/info/github.com/AliSajid/brainfoamkit)
 ![Codecov](https://img.shields.io/codecov/c/github/AliSajid/charx)
 ![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fgithub.com%2FAliSajid%2Fcharx%2Fblob%2Fmain%2FOSSMETADATA)
+![Crates.io MSRV](https://img.shields.io/crates/msrv/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ SPDX-License-Identifier: 0BSD
 ![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fgithub.com%2FAliSajid%2Fcharx%2Fblob%2Fmain%2FOSSMETADATA)
 ![Crates.io MSRV](https://img.shields.io/crates/msrv/charx)
 ![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/charx)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/alisajid/charx/latest)
+![GitHub Created At](https://img.shields.io/github/created-at/AliSajid/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 

--- a/meta/vale-styles/config/vocabularies/Custom/accept.txt
+++ b/meta/vale-styles/config/vocabularies/Custom/accept.txt
@@ -26,3 +26,4 @@ MIT
 (?i)config
 (?i)sex(ual)?
 (?i)codecov
+(?i)codacy


### PR DESCRIPTION
docs: add multiple project badges

- Add the OSS Lifecycle badge
- Add the crates.io MSRV badge
- Add the libraries.io SourceRank badge
- Add GitHub project metadata badges (commits since release, created at)
- Add OSSF badges (Best Practices, Scorecard)
- Add maintainability badges (Codacy, CodeFactor)
- Add the docs.rs build badge
- Update Vale dictionary to include Codacy