### PR TITLE
ci: add code coverage for codacy

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,37 +1,40 @@
 # SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
-
----
 name: Code Coverage
 on:
-    workflow_call:
+  workflow_call:
 jobs:
-    test:
-        name: Generate Coverage
-        runs-on: ubuntu-latest
-        container:
-            image: xd009642/tarpaulin:develop-nightly@sha256:af76a9ddad5f89af054525459758e4436644b38df9dc1ddaaa31366a4d85a5fb
-            options: --security-opt seccomp=unconfined
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-            # Nightly Rust is required for cargo llvm-cov --doc.
-            - uses: dtolnay/rust-toolchain@nightly
-              with:
-                components: llvm-tools-preview
-            - uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
-              with:
-                tool: cargo-llvm-cov,nextest
-            - name: Collect coverage data (including doctests)
-              run: |
-                cargo llvm-cov --no-report nextest --config-file nextest.toml
-                cargo llvm-cov --no-report --doc
-                cargo llvm-cov report --doctests --lcov --output-path lcov.info
-            - name: Upload to codecov.io
-              uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-              with:
-                file: lcov.info
-                token: ${{ secrets.CODECOV_TOKEN }}
-                verbose: true
-                working-directory: .
+  test:
+    name: Generate Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly@sha256:af76a9ddad5f89af054525459758e4436644b38df9dc1ddaaa31366a4d85a5fb
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      # Nightly Rust is required for cargo llvm-cov --doc.
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
+        with:
+          tool: cargo-llvm-cov,nextest
+      - name: Collect coverage data (including doctests)
+        run: |
+          cargo llvm-cov --no-report nextest --config-file nextest.toml
+          cargo llvm-cov --no-report --doc
+          cargo llvm-cov report --doctests --lcov --output-path lcov.info
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          working-directory: .
+      - name: Upload to Codacy
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        with:
+          project-token: ${{secrets.CODACY_PROJECT_TOKEN}}
+          coverage-reports: lcov.info


### PR DESCRIPTION
### TL;DR
Added Codacy code coverage reporting alongside existing Codecov integration.

### What changed?
- Added a new step in the code coverage workflow to upload coverage reports to Codacy
- Integrated the Codacy coverage reporter action with version 1.3.0
- Configured the action to use LCOV coverage report format
- Added Codacy project token secret integration

### How to test?
1. Run the code coverage workflow
2. Verify that coverage reports are successfully uploaded to both Codecov and Codacy
3. Check Codacy dashboard to confirm coverage data is being received
4. Ensure both coverage platforms show consistent results

### Why make this change?
Adding Codacy coverage reporting provides an additional layer of code quality monitoring and allows for cross-validation of coverage metrics between different platforms. This helps maintain high code quality standards and provides more comprehensive coverage analysis.