### PR TITLE
ci: harden security for all workflows

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -19,10 +19,15 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         runs-on: ubuntu-latest
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
             - name: Install Rust
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@ed2356ad628626a6b3f5be6c3e0255c0454fcdb9 # stable
             - name: Install cargo-audit
               uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,11 @@ jobs:
         source_changed: ${{steps.changed_dirs.outputs.source}}
         book_changed: ${{steps.changed_dirs.outputs.book}}
       steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+          with:
+            egress-policy: audit
+
         - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         - name: Check changed directories
           id: changed_dirs
@@ -78,16 +83,21 @@ jobs:
                     - rust: nightly
                       label: nightly
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
             - name: Install Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master
               with:
                 toolchain: ${{matrix.rust}}
                 components: rustfmt, clippy
             - name: Install nightly Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@nightly
+              uses: dtolnay/rust-toolchain@83bdede770b06329615974cf8c786f845d824dfb # nightly
               with:
                 toolchain: nightly
                 components: rustfmt, clippy

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a # v4.4.0

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -10,6 +10,9 @@ on:
             new-release-published:
                 description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
                 value: ${{ jobs.get-next-version.outputs.new-release-published }}
+permissions:
+  contents: read
+
 jobs:
     get-next-version:
         name: Get next release version
@@ -17,6 +20,11 @@ jobs:
         outputs:
             new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ env:
     SEMREL_RUST_VERSION: 2.1.53
 concurrency:
     group: ${{ github.workflow }}
+permissions:
+  contents: read
+
 jobs:
     release:
         name: Semantic Release
@@ -22,6 +25,11 @@ jobs:
             new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
             new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
               with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,3 +148,7 @@ repos:
     rev: v4.0.3
     hooks:
       - id: reuse
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shellcheck


### PR DESCRIPTION
### TL;DR
Added security hardening to GitHub Actions workflows and enhanced pre-commit hooks

### What changed?
- Added StepSecurity's harden-runner to all GitHub Actions workflows for enhanced security
- Added dependency review workflow to scan for vulnerabilities in dependencies
- Added explicit permissions to GitHub Actions workflows
- Pinned action versions with SHA hashes for better security
- Added shellcheck to pre-commit hooks for shell script validation

### How to test?
1. Verify GitHub Actions workflows run successfully with the new security measures
2. Submit a PR with dependency changes to test the dependency review action
3. Run pre-commit hooks on shell scripts to verify shellcheck integration
4. Verify existing CI/CD pipelines continue to function as expected

### Why make this change?
To improve the security posture of the repository by:
- Implementing security best practices for GitHub Actions
- Adding automated dependency vulnerability scanning
- Ensuring shell scripts meet security and quality standards
- Preventing supply chain attacks through action version pinning