### PR TITLE
docs: add a repostatus badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SPDX-License-Identifier: 0BSD
 ![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/AliSajid/charx)
 ![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)
 [![docs.rs](https://img.shields.io/docsrs/charx)](https://docs.rs/charx)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 


### PR DESCRIPTION
### TL;DR

Added repostatus.org badge to indicate active project status

### What changed?

Added a new badge from repostatus.org to the README.md file that indicates this project has reached a stable, usable state and is being actively developed.

### How to test?

1. View the README.md file
2. Verify the new badge appears and links to repostatus.org
3. Confirm the badge shows "Active" status

### Why make this change?

To provide clear visibility of the project's development status to potential users and contributors. The repostatus.org badge is a standardized way to communicate that this project is stable and actively maintained.