### PR TITLE
ci: test the mise-based setup in audit workflow

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -39,4 +39,4 @@ jobs:
                 tool: cargo-audit
 
             - name: Security Audit
-              run: cargo audit
+              run: cargo-audit audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,145 +20,136 @@ env:
   MAXIMUM_WAIT: 10
 permissions: read-all
 jobs:
-  check_changed_dirs:
-    runs-on: ubuntu-latest
-    outputs:
-      source_changed: ${{steps.changed_dirs.outputs.source}}
-      book_changed: ${{steps.changed_dirs.outputs.book}}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Check changed directories
-        id: changed_dirs
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            source:
-              - "src/**/*"
-              - "tests/**/*"
-              - "examples/**/*"
-              - "Cargo.toml"
-              - "Cargo.lock"
-            book:
-              - "guide/src/*.md"
-              - "guide/book.toml"
-  ci:
-    name: Continuous Integration Workflow
-    runs-on: ${{matrix.os}}-latest
-    needs: [check_changed_dirs]
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
-    outputs:
-      result: ${{steps.result.outputs.result}}
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
-          - 1.59.0 # MSRV
-        os:
-          - ubuntu
-          - windows
-          - macos
-        include:
-          - os: windows
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
-          - os: macos
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
-          - os: ubuntu
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
-          - rust: 1.59.0 # MSRV
-            label: msrv
-          - rust: stable
-            label: stable
-          - rust: beta
-            label: beta
-          - rust: nightly
-            label: nightly
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Install Rust
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master
-        with:
-          toolchain: ${{matrix.rust}}
-          components: rustfmt, clippy
-      - name: Install nightly Rust
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: dtolnay/rust-toolchain@83bdede770b06329615974cf8c786f845d824dfb # nightly
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
-      - name: Cache dependencies
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-      - name: Cargo Build
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo build --verbose
-      - name: Cargo Test
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo test
-      - name: Cargo Format
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo +nightly fmt --all -- --check
-      - name: Cargo Lint
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo clippy -- -D warnings
-      - name: Wait before badge creation
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: AliSajid/random-wait-action@f9109712daa7a8103f7be16b68634b9d376587a7 # v2.4.1
-        with:
-          minimum: ${{env.MINIMUM_WAIT}}
-          maximum: ${{env.MAXIMUM_WAIT}}
-      - name: Create Awesome Badge - Success
-        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-        if: success()
-        with:
-          auth: ${{secrets.GIST_SECRET}}
-          gistID: ${{env.GIST_KEY}}
-          filename: ${{matrix.os}}-${{matrix.label}}.json
-          label: Build
-          labelColor: lightgrey
-          logoSvg: ${{matrix.logoSvg}}
-          message: Succeeded
-          color: green
-      - name: Create Awesome Badge - Failure
-        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-        if: failure()
-        with:
-          auth: ${{secrets.GIST_SECRET}}
-          gistID: ${{env.GIST_KEY}}
-          filename: ${{matrix.os}}-${{matrix.label}}.json
-          labelColor: lightgrey
-          logoSvg: ${{matrix.logoSvg}}
-          label: Build
-          message: Failed
-          isError: true
-      - name: Set Result
-        if: always()
-        id: result
-        run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
-  generate_code_coverage:
-    uses: ./.github/workflows/code_coverage.yaml
-    needs: [ci, check_changed_dirs]
-    if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
-    secrets: inherit # pragma: allowlist secret
-  get-next-version:
-    uses: ./.github/workflows/get_next_version.yaml
-    needs: [ci, check_changed_dirs]
-    if: ${{needs.ci.outputs.result == 'success'}}
-    secrets: inherit # pragma: allowlist secret
-  semantic-release:
-    needs: [ci, get-next-version]
-    if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
-    uses: ./.github/workflows/release.yaml
-    secrets: inherit # pragma: allowlist secret
+    check_changed_dirs:
+      runs-on: ubuntu-latest
+      outputs:
+        source_changed: ${{steps.changed_dirs.outputs.source}}
+        book_changed: ${{steps.changed_dirs.outputs.book}}
+      steps:
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        - name: Check changed directories
+          id: changed_dirs
+          uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+          with:
+            base: ${{ github.ref }}
+            filters: |
+              source:
+                - "src/**/*"
+                - "tests/**/*"
+                - "examples/**/*"
+                - "Cargo.toml"
+                - "Cargo.lock"
+              book:
+                - "guide/src/*.md"
+                - "guide/book.toml"
+    ci:
+        runs-on: ${{matrix.os}}-latest
+        needs: [check_changed_dirs]
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
+        outputs:
+            result: ${{steps.result.outputs.result}}
+        strategy:
+            fail-fast: false
+            matrix:
+                rust:
+                    - stable
+                    - beta
+                    - nightly
+                    - 1.59.0 # MSRV
+                os:
+                    - ubuntu
+                    - windows
+                    - macos
+                include:
+                    - os: windows
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
+                    - os: macos
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
+                    - os: ubuntu
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
+                    - rust: 1.59.0 # MSRV
+                      label: msrv
+                    - rust: stable
+                      label: stable
+                    - rust: beta
+                      label: beta
+                    - rust: nightly
+                      label: nightly
+        steps:
+            - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+            - name: Install Rust
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: dtolnay/rust-toolchain@master
+              with:
+                toolchain: ${{matrix.rust}}
+                components: rustfmt, clippy
+            - name: Install nightly Rust
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                toolchain: nightly
+                components: rustfmt, clippy
+            - name: Cache dependencies
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+            - name: Cargo Build
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo build --verbose
+            - name: Cargo Test
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo test
+            - name: Cargo Format
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo +nightly fmt --all -- --check
+            - name: Cargo Lint
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo clippy -- -D warnings
+            - name: Wait before badge creation
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: AliSajid/random-wait-action@f9109712daa7a8103f7be16b68634b9d376587a7 # v2.4.1
+              with:
+                minimum: ${{env.MINIMUM_WAIT}}
+                maximum: ${{env.MAXIMUM_WAIT}}
+            - name: Create Awesome Badge - Success
+              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+              if: success()
+              with:
+                auth: ${{secrets.GIST_SECRET}}
+                gistID: ${{env.GIST_KEY}}
+                filename: ${{matrix.os}}-${{matrix.label}}.json
+                label: Build
+                labelColor: lightgrey
+                logoSvg: ${{matrix.logoSvg}}
+                message: Succeeded
+                color: green
+            - name: Create Awesome Badge - Failure
+              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+              if: failure()
+              with:
+                auth: ${{secrets.GIST_SECRET}}
+                gistID: ${{env.GIST_KEY}}
+                filename: ${{matrix.os}}-${{matrix.label}}.json
+                labelColor: lightgrey
+                logoSvg: ${{matrix.logoSvg}}
+                label: Build
+                message: Failed
+                isError: true
+            - name: Set Result
+              if: always()
+              id: result
+              run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+    generate_code_coverage:
+        uses: ./.github/workflows/code_coverage.yaml
+        needs: [ci, check_changed_dirs]
+        if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
+        secrets: inherit # pragma: allowlist secret
+    get-next-version:
+        uses: ./.github/workflows/get_next_version.yaml
+        needs: [ci, check_changed_dirs]
+        if: ${{needs.ci.outputs.result == 'success'}}
+        secrets: inherit # pragma: allowlist secret
+    semantic-release:
+        needs: [ci, get-next-version]
+        if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
+        uses: ./.github/workflows/release.yaml
+        secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,145 +20,136 @@ env:
   MAXIMUM_WAIT: 10
 permissions: read-all
 jobs:
-  check_changed_dirs:
-    runs-on: ubuntu-latest
-    outputs:
-      source_changed: ${{steps.changed_dirs.outputs.source}}
-      book_changed: ${{steps.changed_dirs.outputs.book}}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Check changed directories
-        id: changed_dirs
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            source:
-              - "src/**/*"
-              - "tests/**/*"
-              - "examples/**/*"
-              - "Cargo.toml"
-              - "Cargo.lock"
-            book:
-              - "guide/src/*.md"
-              - "guide/book.toml"
-  ci:
-    name: Continuous Integration Workflow
-    runs-on: ${{matrix.os}}-latest
-    needs: [check_changed_dirs]
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
-    outputs:
-      result: ${{steps.result.outputs.result}}
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
-          - 1.59.0 # MSRV
-        os:
-          - ubuntu
-          - windows
-          - macos
-        include:
-          - os: windows
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
-          - os: macos
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
-          - os: ubuntu
-            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
-          - rust: 1.59.0 # MSRV
-            label: msrv
-          - rust: stable
-            label: stable
-          - rust: beta
-            label: beta
-          - rust: nightly
-            label: nightly
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install Rust
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # master
-        with:
-          toolchain: ${{matrix.rust}}
-          components: rustfmt, clippy
-      - name: Install nightly Rust
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy
-      - name: Cache dependencies
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - name: Cargo Build
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo build --verbose
-      - name: Cargo Test
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo test
-      - name: Cargo Format
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo +nightly fmt --all -- --check
-      - name: Cargo Lint
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        run: cargo clippy -- -D warnings
-      - name: Wait before badge creation
-        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-        uses: AliSajid/random-wait-action@cd6450856f807a0b8e50d872f4c80f09249ffe59 # v2.11.0
-        with:
-          minimum: ${{env.MINIMUM_WAIT}}
-          maximum: ${{env.MAXIMUM_WAIT}}
-      - name: Create Awesome Badge - Success
-        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-        if: success()
-        with:
-          auth: ${{secrets.GIST_SECRET}}
-          gistID: ${{env.GIST_KEY}}
-          filename: ${{matrix.os}}-${{matrix.label}}.json
-          label: Build
-          labelColor: lightgrey
-          logoSvg: ${{matrix.logoSvg}}
-          message: Succeeded
-          color: green
-      - name: Create Awesome Badge - Failure
-        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-        if: failure()
-        with:
-          auth: ${{secrets.GIST_SECRET}}
-          gistID: ${{env.GIST_KEY}}
-          filename: ${{matrix.os}}-${{matrix.label}}.json
-          labelColor: lightgrey
-          logoSvg: ${{matrix.logoSvg}}
-          label: Build
-          message: Failed
-          isError: true
-      - name: Set Result
-        if: always()
-        id: result
-        run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
-  generate_code_coverage:
-    uses: ./.github/workflows/code_coverage.yaml
-    needs: [ci, check_changed_dirs]
-    if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
-    secrets: inherit # pragma: allowlist secret
-  get-next-version:
-    uses: ./.github/workflows/get_next_version.yaml
-    needs: [ci, check_changed_dirs]
-    if: ${{needs.ci.outputs.result == 'success'}}
-    secrets: inherit # pragma: allowlist secret
-  semantic-release:
-    needs: [ci, get-next-version]
-    if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
-    uses: ./.github/workflows/release.yaml
-    secrets: inherit # pragma: allowlist secret
+    check_changed_dirs:
+      runs-on: ubuntu-latest
+      outputs:
+        source_changed: ${{steps.changed_dirs.outputs.source}}
+        book_changed: ${{steps.changed_dirs.outputs.book}}
+      steps:
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        - name: Check changed directories
+          id: changed_dirs
+          uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+          with:
+            base: ${{ github.ref }}
+            filters: |
+              source:
+                - "src/**/*"
+                - "tests/**/*"
+                - "examples/**/*"
+                - "Cargo.toml"
+                - "Cargo.lock"
+              book:
+                - "guide/src/*.md"
+                - "guide/book.toml"
+    ci:
+        runs-on: ${{matrix.os}}-latest
+        needs: [check_changed_dirs]
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
+        outputs:
+            result: ${{steps.result.outputs.result}}
+        strategy:
+            fail-fast: false
+            matrix:
+                rust:
+                    - stable
+                    - beta
+                    - nightly
+                    - 1.59.0 # MSRV
+                os:
+                    - ubuntu
+                    - windows
+                    - macos
+                include:
+                    - os: windows
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
+                    - os: macos
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
+                    - os: ubuntu
+                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
+                    - rust: 1.59.0 # MSRV
+                      label: msrv
+                    - rust: stable
+                      label: stable
+                    - rust: beta
+                      label: beta
+                    - rust: nightly
+                      label: nightly
+        steps:
+            - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+            - name: Install Rust
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: dtolnay/rust-toolchain@master
+              with:
+                toolchain: ${{matrix.rust}}
+                components: rustfmt, clippy
+            - name: Install nightly Rust
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: dtolnay/rust-toolchain@nightly
+              with:
+                toolchain: nightly
+                components: rustfmt, clippy
+            - name: Cache dependencies
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+            - name: Cargo Build
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo build --verbose
+            - name: Cargo Test
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo test
+            - name: Cargo Format
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo +nightly fmt --all -- --check
+            - name: Cargo Lint
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              run: cargo clippy -- -D warnings
+            - name: Wait before badge creation
+              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+              uses: AliSajid/random-wait-action@f9109712daa7a8103f7be16b68634b9d376587a7 # v2.4.1
+              with:
+                minimum: ${{env.MINIMUM_WAIT}}
+                maximum: ${{env.MAXIMUM_WAIT}}
+            - name: Create Awesome Badge - Success
+              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+              if: success()
+              with:
+                auth: ${{secrets.GIST_SECRET}}
+                gistID: ${{env.GIST_KEY}}
+                filename: ${{matrix.os}}-${{matrix.label}}.json
+                label: Build
+                labelColor: lightgrey
+                logoSvg: ${{matrix.logoSvg}}
+                message: Succeeded
+                color: green
+            - name: Create Awesome Badge - Failure
+              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+              if: failure()
+              with:
+                auth: ${{secrets.GIST_SECRET}}
+                gistID: ${{env.GIST_KEY}}
+                filename: ${{matrix.os}}-${{matrix.label}}.json
+                labelColor: lightgrey
+                logoSvg: ${{matrix.logoSvg}}
+                label: Build
+                message: Failed
+                isError: true
+            - name: Set Result
+              if: always()
+              id: result
+              run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+    generate_code_coverage:
+        uses: ./.github/workflows/code_coverage.yaml
+        needs: [ci, check_changed_dirs]
+        if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
+        secrets: inherit # pragma: allowlist secret
+    get-next-version:
+        uses: ./.github/workflows/get_next_version.yaml
+        needs: [ci, check_changed_dirs]
+        if: ${{needs.ci.outputs.result == 'success'}}
+        secrets: inherit # pragma: allowlist secret
+    semantic-release:
+        needs: [ci, get-next-version]
+        if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
+        uses: ./.github/workflows/release.yaml
+        secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,136 +20,145 @@ env:
   MAXIMUM_WAIT: 10
 permissions: read-all
 jobs:
-    check_changed_dirs:
-      runs-on: ubuntu-latest
-      outputs:
-        source_changed: ${{steps.changed_dirs.outputs.source}}
-        book_changed: ${{steps.changed_dirs.outputs.book}}
-      steps:
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        - name: Check changed directories
-          id: changed_dirs
-          uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-          with:
-            base: ${{ github.ref }}
-            filters: |
-              source:
-                - "src/**/*"
-                - "tests/**/*"
-                - "examples/**/*"
-                - "Cargo.toml"
-                - "Cargo.lock"
-              book:
-                - "guide/src/*.md"
-                - "guide/book.toml"
-    ci:
-        runs-on: ${{matrix.os}}-latest
-        needs: [check_changed_dirs]
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
-        outputs:
-            result: ${{steps.result.outputs.result}}
-        strategy:
-            fail-fast: false
-            matrix:
-                rust:
-                    - stable
-                    - beta
-                    - nightly
-                    - 1.59.0 # MSRV
-                os:
-                    - ubuntu
-                    - windows
-                    - macos
-                include:
-                    - os: windows
-                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
-                    - os: macos
-                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
-                    - os: ubuntu
-                      logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
-                    - rust: 1.59.0 # MSRV
-                      label: msrv
-                    - rust: stable
-                      label: stable
-                    - rust: beta
-                      label: beta
-                    - rust: nightly
-                      label: nightly
-        steps:
-            - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-            - name: Install Rust
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@master
-              with:
-                toolchain: ${{matrix.rust}}
-                components: rustfmt, clippy
-            - name: Install nightly Rust
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@nightly
-              with:
-                toolchain: nightly
-                components: rustfmt, clippy
-            - name: Cache dependencies
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-            - name: Cargo Build
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              run: cargo build --verbose
-            - name: Cargo Test
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              run: cargo test
-            - name: Cargo Format
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              run: cargo +nightly fmt --all -- --check
-            - name: Cargo Lint
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              run: cargo clippy -- -D warnings
-            - name: Wait before badge creation
-              if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: AliSajid/random-wait-action@f9109712daa7a8103f7be16b68634b9d376587a7 # v2.4.1
-              with:
-                minimum: ${{env.MINIMUM_WAIT}}
-                maximum: ${{env.MAXIMUM_WAIT}}
-            - name: Create Awesome Badge - Success
-              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-              if: success()
-              with:
-                auth: ${{secrets.GIST_SECRET}}
-                gistID: ${{env.GIST_KEY}}
-                filename: ${{matrix.os}}-${{matrix.label}}.json
-                label: Build
-                labelColor: lightgrey
-                logoSvg: ${{matrix.logoSvg}}
-                message: Succeeded
-                color: green
-            - name: Create Awesome Badge - Failure
-              uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
-              if: failure()
-              with:
-                auth: ${{secrets.GIST_SECRET}}
-                gistID: ${{env.GIST_KEY}}
-                filename: ${{matrix.os}}-${{matrix.label}}.json
-                labelColor: lightgrey
-                logoSvg: ${{matrix.logoSvg}}
-                label: Build
-                message: Failed
-                isError: true
-            - name: Set Result
-              if: always()
-              id: result
-              run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
-    generate_code_coverage:
-        uses: ./.github/workflows/code_coverage.yaml
-        needs: [ci, check_changed_dirs]
-        if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
-        secrets: inherit # pragma: allowlist secret
-    get-next-version:
-        uses: ./.github/workflows/get_next_version.yaml
-        needs: [ci, check_changed_dirs]
-        if: ${{needs.ci.outputs.result == 'success'}}
-        secrets: inherit # pragma: allowlist secret
-    semantic-release:
-        needs: [ci, get-next-version]
-        if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
-        uses: ./.github/workflows/release.yaml
-        secrets: inherit # pragma: allowlist secret
+  check_changed_dirs:
+    runs-on: ubuntu-latest
+    outputs:
+      source_changed: ${{steps.changed_dirs.outputs.source}}
+      book_changed: ${{steps.changed_dirs.outputs.book}}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Check changed directories
+        id: changed_dirs
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            source:
+              - "src/**/*"
+              - "tests/**/*"
+              - "examples/**/*"
+              - "Cargo.toml"
+              - "Cargo.lock"
+            book:
+              - "guide/src/*.md"
+              - "guide/book.toml"
+  ci:
+    name: Continuous Integration Workflow
+    runs-on: ${{matrix.os}}-latest
+    needs: [check_changed_dirs]
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
+    outputs:
+      result: ${{steps.result.outputs.result}}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - 1.59.0 # MSRV
+        os:
+          - ubuntu
+          - windows
+          - macos
+        include:
+          - os: windows
+            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Windows</title><path d=\"M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623\"/></svg>"
+          - os: macos
+            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Apple</title><path d=\"M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701\"/></svg>"
+          - os: ubuntu
+            logoSvg: "<svg role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Ubuntu</title><path d=\"M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z\"/></svg>"
+          - rust: 1.59.0 # MSRV
+            label: msrv
+          - rust: stable
+            label: stable
+          - rust: beta
+            label: beta
+          - rust: nightly
+            label: nightly
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Install Rust
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master
+        with:
+          toolchain: ${{matrix.rust}}
+          components: rustfmt, clippy
+      - name: Install nightly Rust
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        uses: dtolnay/rust-toolchain@83bdede770b06329615974cf8c786f845d824dfb # nightly
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+      - name: Cache dependencies
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+      - name: Cargo Build
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        run: cargo build --verbose
+      - name: Cargo Test
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        run: cargo test
+      - name: Cargo Format
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        run: cargo +nightly fmt --all -- --check
+      - name: Cargo Lint
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        run: cargo clippy -- -D warnings
+      - name: Wait before badge creation
+        if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
+        uses: AliSajid/random-wait-action@f9109712daa7a8103f7be16b68634b9d376587a7 # v2.4.1
+        with:
+          minimum: ${{env.MINIMUM_WAIT}}
+          maximum: ${{env.MAXIMUM_WAIT}}
+      - name: Create Awesome Badge - Success
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        if: success()
+        with:
+          auth: ${{secrets.GIST_SECRET}}
+          gistID: ${{env.GIST_KEY}}
+          filename: ${{matrix.os}}-${{matrix.label}}.json
+          label: Build
+          labelColor: lightgrey
+          logoSvg: ${{matrix.logoSvg}}
+          message: Succeeded
+          color: green
+      - name: Create Awesome Badge - Failure
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        if: failure()
+        with:
+          auth: ${{secrets.GIST_SECRET}}
+          gistID: ${{env.GIST_KEY}}
+          filename: ${{matrix.os}}-${{matrix.label}}.json
+          labelColor: lightgrey
+          logoSvg: ${{matrix.logoSvg}}
+          label: Build
+          message: Failed
+          isError: true
+      - name: Set Result
+        if: always()
+        id: result
+        run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+  generate_code_coverage:
+    uses: ./.github/workflows/code_coverage.yaml
+    needs: [ci, check_changed_dirs]
+    if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
+    secrets: inherit # pragma: allowlist secret
+  get-next-version:
+    uses: ./.github/workflows/get_next_version.yaml
+    needs: [ci, check_changed_dirs]
+    if: ${{needs.ci.outputs.result == 'success'}}
+    secrets: inherit # pragma: allowlist secret
+  semantic-release:
+    needs: [ci, get-next-version]
+    if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -3,59 +3,53 @@
 # SPDX-License-Identifier: 0BSD
 name: Next semantic-release version
 on:
-  workflow_call:
-    outputs:
-      new-release-published:
-        description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
-        value: ${{ jobs.get-next-version.outputs.new-release-published }}
-permissions:
-  contents: read
+    workflow_call:
+        outputs:
+            new-release-published:
+                description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
+                value: ${{ jobs.get-next-version.outputs.new-release-published }}
 jobs:
-  get-next-version:
-    name: Get next release version
-    runs-on: ubuntu-latest
-    outputs:
-      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Configure Node.js
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-        with:
-          node-version: lts/*
-      - name: Cache action npm dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: cache-node-modules
-        with:
-          path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
-          key: |
-            semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
-      - name: Install dependencies on cache miss
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: |
-          npm install -g semantic-release semantic-release-export-data
-        shell: bash
-      - name: Get next release version
-        id: get-next-version
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-        run: |
-          : calculate next semantic-release version
-          semantic-release \
-          --dry-run \
-          --plugins semantic-release-export-data \
-          --verify-conditions semantic-release-export-data \
-          --verify-release '' \
-          --generate-notes semantic-release-export-data \
-          --prepare '' \
-          --publish '' \
-          --success '' \
-          --fail ''
-        shell: bash
+    get-next-version:
+        name: Get next release version
+        runs-on: ubuntu-latest
+        outputs:
+            new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+              with:
+                fetch-depth: 0
+                persist-credentials: false
+            - name: Configure Node.js
+              uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+              with:
+                node-version: lts/*
+            - name: Cache action npm dependencies
+              uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+              id: cache-node-modules
+              with:
+                path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
+                key: |
+                    semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
+            - name: Install dependencies on cache miss
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: |
+                npm install -g semantic-release semantic-release-export-data
+              shell: bash
+            - name: Get next release version
+              id: get-next-version
+              env:
+                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+              run: |
+                : calculate next semantic-release version
+                semantic-release \
+                --dry-run \
+                --plugins semantic-release-export-data \
+                --verify-conditions semantic-release-export-data \
+                --verify-release '' \
+                --generate-notes semantic-release-export-data \
+                --prepare '' \
+                --publish '' \
+                --success '' \
+                --fail ''
+              shell: bash

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -3,53 +3,59 @@
 # SPDX-License-Identifier: 0BSD
 name: Next semantic-release version
 on:
-    workflow_call:
-        outputs:
-            new-release-published:
-                description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
-                value: ${{ jobs.get-next-version.outputs.new-release-published }}
+  workflow_call:
+    outputs:
+      new-release-published:
+        description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
+        value: ${{ jobs.get-next-version.outputs.new-release-published }}
+permissions:
+  contents: read
 jobs:
-    get-next-version:
-        name: Get next release version
-        runs-on: ubuntu-latest
-        outputs:
-            new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-              with:
-                fetch-depth: 0
-                persist-credentials: false
-            - name: Configure Node.js
-              uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-              with:
-                node-version: lts/*
-            - name: Cache action npm dependencies
-              uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-              id: cache-node-modules
-              with:
-                path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
-                key: |
-                    semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
-            - name: Install dependencies on cache miss
-              if: steps.cache-node-modules.outputs.cache-hit != 'true'
-              run: |
-                npm install -g semantic-release semantic-release-export-data
-              shell: bash
-            - name: Get next release version
-              id: get-next-version
-              env:
-                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-              run: |
-                : calculate next semantic-release version
-                semantic-release \
-                --dry-run \
-                --plugins semantic-release-export-data \
-                --verify-conditions semantic-release-export-data \
-                --verify-release '' \
-                --generate-notes semantic-release-export-data \
-                --prepare '' \
-                --publish '' \
-                --success '' \
-                --fail ''
-              shell: bash
+  get-next-version:
+    name: Get next release version
+    runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Configure Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: lts/*
+      - name: Cache action npm dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        id: cache-node-modules
+        with:
+          path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
+          key: |
+            semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
+      - name: Install dependencies on cache miss
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: |
+          npm install -g semantic-release semantic-release-export-data
+        shell: bash
+      - name: Get next release version
+        id: get-next-version
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+        run: |
+          : calculate next semantic-release version
+          semantic-release \
+          --dry-run \
+          --plugins semantic-release-export-data \
+          --verify-conditions semantic-release-export-data \
+          --verify-release '' \
+          --generate-notes semantic-release-export-data \
+          --prepare '' \
+          --publish '' \
+          --success '' \
+          --fail ''
+        shell: bash

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -3,59 +3,53 @@
 # SPDX-License-Identifier: 0BSD
 name: Next semantic-release version
 on:
-  workflow_call:
-    outputs:
-      new-release-published:
-        description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
-        value: ${{ jobs.get-next-version.outputs.new-release-published }}
-permissions:
-  contents: read
+    workflow_call:
+        outputs:
+            new-release-published:
+                description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
+                value: ${{ jobs.get-next-version.outputs.new-release-published }}
 jobs:
-  get-next-version:
-    name: Get next release version
-    runs-on: ubuntu-latest
-    outputs:
-      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Configure Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: lts/*
-      - name: Cache action npm dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        id: cache-node-modules
-        with:
-          path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
-          key: |
-            semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
-      - name: Install dependencies on cache miss
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: |
-          npm install -g semantic-release semantic-release-export-data
-        shell: bash
-      - name: Get next release version
-        id: get-next-version
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-        run: |
-          : calculate next semantic-release version
-          semantic-release \
-          --dry-run \
-          --plugins semantic-release-export-data \
-          --verify-conditions semantic-release-export-data \
-          --verify-release '' \
-          --generate-notes semantic-release-export-data \
-          --prepare '' \
-          --publish '' \
-          --success '' \
-          --fail ''
-        shell: bash
+    get-next-version:
+        name: Get next release version
+        runs-on: ubuntu-latest
+        outputs:
+            new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+              with:
+                fetch-depth: 0
+                persist-credentials: false
+            - name: Configure Node.js
+              uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+              with:
+                node-version: lts/*
+            - name: Cache action npm dependencies
+              uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+              id: cache-node-modules
+              with:
+                path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
+                key: |
+                    semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
+            - name: Install dependencies on cache miss
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: |
+                npm install -g semantic-release semantic-release-export-data
+              shell: bash
+            - name: Get next release version
+              id: get-next-version
+              env:
+                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+              run: |
+                : calculate next semantic-release version
+                semantic-release \
+                --dry-run \
+                --plugins semantic-release-export-data \
+                --verify-conditions semantic-release-export-data \
+                --verify-release '' \
+                --generate-notes semantic-release-export-data \
+                --prepare '' \
+                --publish '' \
+                --success '' \
+                --fail ''
+              shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,62 +8,56 @@ env:
   RUST_BACKTRACE: 1
   SEMREL_RUST_VERSION: 2.1.53
 concurrency:
-  group: ${{ github.workflow }}
-permissions:
-  contents: read
+    group: ${{ github.workflow }}
 jobs:
-  release:
-    name: Semantic Release
-    runs-on: ubuntu-latest
-    outputs:
-      new_release_version: ${{steps.semantic.outputs.new_release_version}}
-      new_release_published: ${{steps.semantic.outputs.new_release_published}}
-      new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
-      new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-          fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
-          trust_level: 5
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_tag_gpgsign: false
-          git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
-          git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
-      - name: Test GPG Key Import
-        run: gpg --list-keys --keyid-format LONG
-      - name: Install dependencies
-        run: sudo apt install tree
-      - name: Install semantic-release-cargo
-        uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
-        with:
-          tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
-      - name: Install Conventional Commit preset
-        run: npm install conventional-changelog-conventionalcommits
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4.1.0
-        id: semantic
-        with:
-          semantic_version: 24.0.0
-          extra_plugins: |
-            @semantic-release/exec@6
-            @semantic-release/git@10
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-          CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
-          GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
-          GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
-          GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
-          GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+    release:
+        name: Semantic Release
+        runs-on: ubuntu-latest
+        outputs:
+            new_release_version: ${{steps.semantic.outputs.new_release_version}}
+            new_release_published: ${{steps.semantic.outputs.new_release_published}}
+            new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
+            new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+              with:
+                fetch-depth: 0
+                persist-credentials: false
+            - name: Import GPG key
+              uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+              with:
+                gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+                fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
+                trust_level: 5
+                git_user_signingkey: true
+                git_commit_gpgsign: true
+                git_tag_gpgsign: false
+                git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
+                git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
+            - name: Test GPG Key Import
+              run: gpg --list-keys --keyid-format LONG
+            - name: Install dependencies
+              run: sudo apt install tree
+            - name: Install semantic-release-cargo
+              uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
+              with:
+                tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
+            - name: Install Conventional Commit preset
+              run: npm install conventional-changelog-conventionalcommits
+            - name: Semantic Release
+              uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4.1.0
+              id: semantic
+              with:
+                semantic_version: 24.0.0
+                extra_plugins: |
+                    @semantic-release/exec@6
+                    @semantic-release/git@10
+              env:
+                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+                CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
+                GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
+                GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+                GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
+                GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,56 +8,62 @@ env:
   RUST_BACKTRACE: 1
   SEMREL_RUST_VERSION: 2.1.53
 concurrency:
-    group: ${{ github.workflow }}
+  group: ${{ github.workflow }}
+permissions:
+  contents: read
 jobs:
-    release:
-        name: Semantic Release
-        runs-on: ubuntu-latest
-        outputs:
-            new_release_version: ${{steps.semantic.outputs.new_release_version}}
-            new_release_published: ${{steps.semantic.outputs.new_release_published}}
-            new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
-            new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-              with:
-                fetch-depth: 0
-                persist-credentials: false
-            - name: Import GPG key
-              uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
-              with:
-                gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-                passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-                fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
-                trust_level: 5
-                git_user_signingkey: true
-                git_commit_gpgsign: true
-                git_tag_gpgsign: false
-                git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
-                git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
-            - name: Test GPG Key Import
-              run: gpg --list-keys --keyid-format LONG
-            - name: Install dependencies
-              run: sudo apt install tree
-            - name: Install semantic-release-cargo
-              uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
-              with:
-                tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
-            - name: Install Conventional Commit preset
-              run: npm install conventional-changelog-conventionalcommits
-            - name: Semantic Release
-              uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4.1.0
-              id: semantic
-              with:
-                semantic_version: 24.0.0
-                extra_plugins: |
-                    @semantic-release/exec@6
-                    @semantic-release/git@10
-              env:
-                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-                CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
-                GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
-                GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
-                GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
-                GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_release_version: ${{steps.semantic.outputs.new_release_version}}
+      new_release_published: ${{steps.semantic.outputs.new_release_published}}
+      new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
+      new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
+          trust_level: 5
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: false
+          git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
+          git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
+      - name: Test GPG Key Import
+        run: gpg --list-keys --keyid-format LONG
+      - name: Install dependencies
+        run: sudo apt install tree
+      - name: Install semantic-release-cargo
+        uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
+        with:
+          tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
+      - name: Install Conventional Commit preset
+        run: npm install conventional-changelog-conventionalcommits
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4.1.0
+        id: semantic
+        with:
+          semantic_version: 24.0.0
+          extra_plugins: |
+            @semantic-release/exec@6
+            @semantic-release/git@10
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+          CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
+          GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
+          GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+          GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
+          GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,62 +8,56 @@ env:
   RUST_BACKTRACE: 1
   SEMREL_RUST_VERSION: 2.1.53
 concurrency:
-  group: ${{ github.workflow }}
-permissions:
-  contents: read
+    group: ${{ github.workflow }}
 jobs:
-  release:
-    name: Semantic Release
-    runs-on: ubuntu-latest
-    outputs:
-      new_release_version: ${{steps.semantic.outputs.new_release_version}}
-      new_release_published: ${{steps.semantic.outputs.new_release_published}}
-      new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
-      new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-          fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
-          trust_level: 5
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_tag_gpgsign: false
-          git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
-          git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
-      - name: Test GPG Key Import
-        run: gpg --list-keys --keyid-format LONG
-      - name: Install dependencies
-        run: sudo apt install tree
-      - name: Install semantic-release-cargo
-        uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
-        with:
-          tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
-      - name: Install Conventional Commit preset
-        run: npm install conventional-changelog-conventionalcommits
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
-        id: semantic
-        with:
-          semantic_version: 24.0.0
-          extra_plugins: |
-            @semantic-release/exec@6
-            @semantic-release/git@10
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
-          CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
-          GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
-          GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
-          GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
-          GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+    release:
+        name: Semantic Release
+        runs-on: ubuntu-latest
+        outputs:
+            new_release_version: ${{steps.semantic.outputs.new_release_version}}
+            new_release_published: ${{steps.semantic.outputs.new_release_published}}
+            new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
+            new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+              with:
+                fetch-depth: 0
+                persist-credentials: false
+            - name: Import GPG key
+              uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+              with:
+                gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+                fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
+                trust_level: 5
+                git_user_signingkey: true
+                git_commit_gpgsign: true
+                git_tag_gpgsign: false
+                git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
+                git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
+            - name: Test GPG Key Import
+              run: gpg --list-keys --keyid-format LONG
+            - name: Install dependencies
+              run: sudo apt install tree
+            - name: Install semantic-release-cargo
+              uses: taiki-e/install-action@f2b65a3e67b2ba5ed3b4a631b5e460896e975708 # v2.42.37
+              with:
+                tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
+            - name: Install Conventional Commit preset
+              run: npm install conventional-changelog-conventionalcommits
+            - name: Semantic Release
+              uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4.1.0
+              id: semantic
+              with:
+                semantic_version: 24.0.0
+                extra_plugins: |
+                    @semantic-release/exec@6
+                    @semantic-release/git@10
+              env:
+                GITHUB_TOKEN: ${{secrets.ACTIONS_PAT_GITHUB}}
+                CARGO_REGISTRY_TOKEN: ${{secrets.SEMREL_CRATES_IO}}
+                GIT_AUTHOR_NAME: ${{vars.GIT_AUTHOR_NAME}}
+                GIT_AUTHOR_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}
+                GIT_COMMITTER_NAME: ${{vars.GIT_AUTHOR_NAME}}
+                GIT_COMMITTER_EMAIL: ${{vars.GIT_AUTHOR_EMAIL}}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -17,11 +17,9 @@ on:
   schedule:
     - cron: '22 9 * * 3'
   push:
-    branches: [ "main" ]
-
+    branches: ["main", "next"]
 # Declare default permissions as read only.
 permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
@@ -34,18 +32,15 @@ jobs:
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
-
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-
       - name: "Run analysis"
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
@@ -65,7 +60,6 @@ jobs:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
           publish_results: true
-
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
@@ -74,7 +68,6 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -17,9 +17,11 @@ on:
   schedule:
     - cron: '22 9 * * 3'
   push:
-    branches: ["main", "next"]
+    branches: [ "main" ]
+
 # Declare default permissions as read only.
 permissions: read-all
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -32,15 +34,18 @@ jobs:
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+
       - name: "Run analysis"
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
@@ -60,6 +65,7 @@ jobs:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
           publish_results: true
+
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
@@ -68,6 +74,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
+
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"

--- a/meta/vale-styles/config/vocabularies/Custom/accept.txt
+++ b/meta/vale-styles/config/vocabularies/Custom/accept.txt
@@ -26,3 +26,4 @@ MIT
 (?i)config
 (?i)sex(ual)?
 (?i)codecov
+(?i)codacy

--- a/meta/vale-styles/config/vocabularies/Custom/accept.txt
+++ b/meta/vale-styles/config/vocabularies/Custom/accept.txt
@@ -26,4 +26,3 @@ MIT
 (?i)config
 (?i)sex(ual)?
 (?i)codecov
-(?i)codacy

--- a/mise.audit.toml
+++ b/mise.audit.toml
@@ -1,0 +1,3 @@
+[tools]
+"cargo:cargo-audit" = "0.21.0"
+rust = "1.85.1"


### PR DESCRIPTION
### TL;DR

Switch from manual Rust and cargo-audit installation to using mise for dependency management in the security audit workflow.

### What changed?

- Replaced the separate Rust toolchain and cargo-audit installation steps with mise-action
- Added a new `mise.audit.toml` configuration file specifying Rust 1.85.1 and cargo-audit 0.21.0
- Updated the audit command from `cargo audit` to `cargo-audit audit`
- Added a debug step to verify cargo-audit installation
- Added "codacy" to the Vale styles accepted vocabulary list

### How to test?

1. Run the GitHub Actions workflow to ensure the security audit completes successfully
2. Verify that mise correctly installs the specified versions of Rust and cargo-audit
3. Confirm that the audit runs with the proper command

### Why make this change?

Using mise provides a more consistent and declarative approach to managing tool dependencies in CI workflows. This change standardizes the tooling approach and ensures specific versions of Rust and cargo-audit are used, improving reproducibility and reliability of the security audit process.