### PR TITLE
ci: update CI workflows

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -12,6 +12,11 @@ jobs:
       image: xd009642/tarpaulin:develop-nightly@sha256:feeacc46b481a519b573e09edbd2c438e1c9fae89317ed312fbd00dfd1dacb54
       options: --security-opt seccomp=unconfined
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Nightly Rust is required for cargo llvm-cov --doc.
@@ -21,11 +26,13 @@ jobs:
       - uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
         with:
           tool: cargo-llvm-cov,nextest
+
       - name: Collect coverage data (including doctests)
         run: |
           cargo llvm-cov --no-report nextest --config-file nextest.toml
           cargo llvm-cov --no-report --doc
           cargo llvm-cov report --doctests --lcov --output-path lcov.info
+
       - name: Upload to codecov.io
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
@@ -33,6 +40,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           working-directory: .
+
       - name: Upload to Codacy
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -9,29 +9,19 @@
 
 name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
-  # To guarantee Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '22 9 * * 3'
   push:
     branches: ["main", "next"]
-# Declare default permissions as read only.
+
 permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
### TL;DR

Added security hardening to GitHub Actions workflows.

### What changed?

- Added the `step-security/harden-runner` action to the `code_coverage.yaml` workflow to audit all outbound network calls
- Improved formatting in the `code_coverage.yaml` workflow by adding blank lines between steps
- Simplified the `scorecard.yaml` workflow by removing the `branch_protection_rule` trigger and unnecessary comments

### How to test?

1. Verify that the GitHub Actions workflows run successfully with the added security hardening
2. Check that the code coverage workflow properly audits outbound network calls
3. Confirm that the scorecard workflow still runs on schedule and on pushes to main/next branches

### Why make this change?

This change enhances the security posture of the CI/CD pipeline by monitoring and auditing network traffic from GitHub Actions runners. The harden-runner action helps detect potential security issues by tracking all outbound network calls, which can help identify unexpected or malicious network activity during workflow execution.