### PR TITLE
ci: fix versions of github actions

### DIFF
--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -26,21 +26,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Setup PNPM
       - name: Configure Node.js
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
-      - name: Cache action npm dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: cache-node-modules
-        with:
-          path: ${{ runner.temp }}/.semantic-release-action_next-release-version/node_modules
-          key: |
-            semantic-release-action/next-release-version-${{ runner.os }}-node-${{ hashFiles('${{ github.action_path }}/package-lock.json') }}
+          cache: pnpm
       - name: Install dependencies on cache miss
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |
-          npm install -g semantic-release semantic-release-export-data
+          pnpm install -g semantic-release semantic-release-export-data
         shell: bash
       - name: Get next release version
         id: get-next-version


### PR DESCRIPTION
### TL;DR

Update GitHub workflow to use PNPM instead of NPM for dependency management.

### What changed?

- Added PNPM setup action (`pnpm/action-setup@v4.1.0`)
- Updated Node.js setup action to the latest version (`v4.4.0`)
- Configured Node.js setup to use PNPM cache
- Replaced NPM install commands with PNPM equivalents
- Removed the custom NPM cache step as it's now handled by the Node.js setup

### How to test?

1. Run the GitHub workflow manually to verify it completes successfully
2. Confirm that the workflow correctly determines the next version
3. Verify that PNPM correctly installs and caches the semantic-release dependencies

### Why make this change?

This change standardizes the workflow to use PNPM, which provides faster and more efficient dependency management compared to NPM. It also simplifies the caching mechanism by leveraging the built-in cache support in the Node.js setup action rather than using a separate cache step.