### PR TITLE
docs(README): fixed the scorecard.dev reference to point to the current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ SPDX-License-Identifier: 0BSD
 
 [![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/charx)](https://libraries.io/cargo/charx)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9684/badge)](https://www.bestpractices.dev/projects/9684)
-[![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)](https://scorecard.dev/viewer/?uri=github.com/AliSajid/random-wait-action)
+[![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/AliSajid/charx)](https://scorecard.dev/viewer/?uri=github.com/AliSajid/charx)
 
 [![Code of Conduct: Contributor Covenant](https://img.shields.io/badge/code_of_conduct-contributor_covenant-14cc21)](https://github.com/EthicalSource/contributor_covenant)
 


### PR DESCRIPTION
### TL;DR

Fixed the OSSF-Scorecard link in the README.md badge.

### What changed?

Updated the OSSF-Scorecard badge link in the README.md file to point to the correct repository. The link previously pointed to `github.com/AliSajid/random-wait-action` but now correctly points to `github.com/AliSajid/charx`.

### How to test?

1. Click on the OSSF-Scorecard badge in the README.md
2. Verify that it takes you to the scorecard for the `charx` repository, not the `random-wait-action` repository

### Why make this change?

The incorrect link was likely a copy-paste error from another project. This change ensures that users clicking on the badge will see the security scorecard for the correct repository, providing accurate information about the project's security practices.