### PR TITLE
build(license): update license years for the repository

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 name: Security Audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 name: Continuous integration

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 name: Code Coverage

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 name: Next semantic-release version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 on:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 SPDX-FileCopyrightText: 2022 - 2024 Soni L.
 
 SPDX-License-Identifier: 0BSD

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -12,13 +12,13 @@ path = [
   ".markdownlintignore",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "Cargo.lock"
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "0BSD"
 
 [[annotations]]
@@ -35,29 +35,29 @@ path = [
   "OSSMETADATA",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ".github/workflows/*"
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = [".github/ISSUE_TEMPLATE/*", ".github/PULL_REQUEST_TEMPLATE.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ["CHANGELOG.md"]
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ["meta/vale-styles/config/vocabularies/**/*.txt"]
 precedence = "override"
-SPDX-FileCopyrightText = "2022 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2022 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"

--- a/about.toml
+++ b/about.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/licenses_report.json
+++ b/licenses_report.json
@@ -12,7 +12,7 @@
                 "edition": "2021",
                 "features": {},
                 "homepage": null,
-                "id": "path+file:///Users/aimami/experiments/rust-projects/charx#1.0.2",
+                "id": "path+file:///Users/aimami/experiments/rust-projects/charx#1.1.0",
                 "keywords": [],
                 "license": "0BSD",
                 "license_file": null,
@@ -45,7 +45,7 @@
                         "test": true
                     }
                 ],
-                "version": "1.0.2"
+                "version": "1.1.0"
             }
         }
     ],
@@ -68,7 +68,7 @@
                         "edition": "2021",
                         "features": {},
                         "homepage": null,
-                        "id": "path+file:///Users/aimami/experiments/rust-projects/charx#1.0.2",
+                        "id": "path+file:///Users/aimami/experiments/rust-projects/charx#1.1.0",
                         "keywords": [],
                         "license": "0BSD",
                         "license_file": null,
@@ -101,7 +101,7 @@
                                 "test": true
                             }
                         ],
-                        "version": "1.0.2"
+                        "version": "1.1.0"
                     },
                     "path": null
                 }

--- a/licenses_report.md
+++ b/licenses_report.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->
@@ -21,7 +21,7 @@ BSD Zero Clause License
 
 #### Used by
 
-- [charx]( https://github.com/AliSajid/charx ) 1.0.2
+- [charx]( https://github.com/AliSajid/charx ) 1.1.0
 
 #### License
 

--- a/meta/licenses.hbs
+++ b/meta/licenses.hbs
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: 0BSD
 -->

--- a/scripts/generate_about_json.sh
+++ b/scripts/generate_about_json.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 

--- a/scripts/generate_about_md.sh
+++ b/scripts/generate_about_md.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: 0BSD
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Soni L.
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: 0BSD
 


### PR DESCRIPTION
### TL;DR

Updated copyright year from 2024 to 2025 across all project files.

### What changed?

- Updated the copyright year in SPDX license headers from "2022 - 2024" to "2022 - 2025" in all project files
- Updated version references in licenses_report.json and licenses_report.md from 1.0.2 to 1.1.0

### How to test?

- Verify that all SPDX-FileCopyrightText headers now show "2022 - 2025"
- Confirm that version references in license reports correctly show 1.1.0

### Why make this change?

This is a proactive update to extend copyright coverage into 2025, ensuring proper attribution for the upcoming year. The version number updates in the license reports align with the current project version.