### PR TITLE
ci(permissions): update ci top-level and job-level permissions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -13,7 +13,8 @@ on:
       - '**/Cargo.lock'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
     security_audit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: 0BSD
 name: Continuous integration
+
 on:
   push:
   pull_request:
@@ -10,15 +11,20 @@ on:
     types:
       - closed
   workflow_dispatch:
+
 concurrency:
   group: ${{github.event.ref}}
   cancel-in-progress: true
+
 env:
   GIST_KEY: d52f912107d7609656370db9d741596c # pragma: allowlist secret
   RUST_BACKTRACE: 1
   MINIMUM_WAIT: 3
   MAXIMUM_WAIT: 10
-permissions: read-all
+
+permissions:
+  contents: read
+
 jobs:
   check_changed_dirs:
     runs-on: ubuntu-latest

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -2,8 +2,13 @@
 #
 # SPDX-License-Identifier: 0BSD
 name: Code Coverage
+
 on:
   workflow_call:
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Generate Coverage
@@ -19,10 +24,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      # Nightly Rust is required for cargo llvm-cov --doc.
+
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
+
       - uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
         with:
           tool: cargo-llvm-cov,nextest

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -2,14 +2,17 @@
 #
 # SPDX-License-Identifier: 0BSD
 name: Next semantic-release version
+
 on:
   workflow_call:
     outputs:
       new-release-published:
         description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
         value: ${{ jobs.get-next-version.outputs.new-release-published }}
+
 permissions:
   contents: read
+
 jobs:
   get-next-version:
     name: Get next release version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,19 @@
 # SPDX-License-Identifier: 0BSD
 on:
   workflow_call:
+
 name: Semantic Release
+
 env:
   RUST_BACKTRACE: 1
   SEMREL_RUST_VERSION: 2.1.53
+
 concurrency:
   group: ${{ github.workflow }}
+
 permissions:
   contents: read
+
 jobs:
   release:
     name: Semantic Release
@@ -25,11 +30,13 @@ jobs:
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
@@ -42,16 +49,21 @@ jobs:
           git_tag_gpgsign: false
           git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
           git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
+
       - name: Test GPG Key Import
         run: gpg --list-keys --keyid-format LONG
+
       - name: Install dependencies
         run: sudo apt install tree
+
       - name: Install semantic-release-cargo
         uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
         with:
           tool: semantic-release-cargo@${{env.SEMREL_RUST_VERSION}}
+
       - name: Install Conventional Commit preset
         run: npm install conventional-changelog-conventionalcommits
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -8,13 +8,16 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+
 on:
   schedule:
     - cron: '22 9 * * 3'
   push:
     branches: ["main", "next"]
 
-permissions: read-all
+permissions:
+  contents: read
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -27,39 +30,26 @@ jobs:
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+
       - name: "Run analysis"
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
           publish_results: true
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
+
       - name: "Upload artifact"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.pre.node20
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
         with:


### PR DESCRIPTION
### TL;DR

Improved GitHub Actions workflow files by standardizing permissions and formatting.

### What changed?

- Replaced `permissions: read-all` with explicit `permissions: contents: read` in multiple workflow files
- Added consistent spacing between workflow sections for better readability
- Removed unnecessary comments in the scorecard workflow
- Fixed formatting and structure across all workflow files:
  - audit.yaml
  - ci.yaml
  - code_coverage.yaml
  - get_next_version.yaml
  - release.yaml
  - scorecard.yaml

### How to test?

Run the GitHub Actions workflows to verify they function correctly with the updated permissions model. The workflows should continue to operate as before but with more explicit permissions.

### Why make this change?

This change follows security best practices by explicitly defining the minimum required permissions for each workflow rather than using the broad `read-all` permission. The consistent formatting also improves readability and maintainability of the workflow files.