### PR TITLE
ci(permissions): switch to harden-runner 'block' policy

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -24,7 +24,15 @@ jobs:
             - name: Harden Runner
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
               with:
-                egress-policy: audit
+                egress-policy: block
+                allowed-endpoints: >
+                  github.com:443
+                  index.crates.io:443
+                  mise-versions.jdx.dev:80
+                  mise.jdx.dev:443
+                  objects.githubusercontent.com:443
+                  static.crates.io:443
+                  static.rust-lang.org:443
 
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Check changed directories
         id: changed_dirs
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -52,6 +56,7 @@ jobs:
             book:
               - "guide/src/*.md"
               - "guide/book.toml"
+
   ci:
     name: Continuous Integration Workflow
     runs-on: ${{matrix.os}}-latest
@@ -90,8 +95,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            static.rust-lang.org:443
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Install Rust
         if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # master
@@ -153,16 +164,19 @@ jobs:
         if: always()
         id: result
         run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+
   generate_code_coverage:
     uses: ./.github/workflows/code_coverage.yaml
     needs: [ci, check_changed_dirs]
     if: ${{needs.check_changed_dirs.outputs.source_changed == 'true'}}
     secrets: inherit # pragma: allowlist secret
+
   get-next-version:
     uses: ./.github/workflows/get_next_version.yaml
     needs: [ci, check_changed_dirs]
     if: ${{needs.ci.outputs.result == 'success'}}
     secrets: inherit # pragma: allowlist secret
+
   semantic-release:
     needs: [ci, get-next-version]
     if: ${{needs.get-next-version.outputs.new-release-published == 'true'}}

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -16,6 +16,7 @@ jobs:
     container:
       image: xd009642/tarpaulin:develop-nightly@sha256:feeacc46b481a519b573e09edbd2c438e1c9fae89317ed312fbd00dfd1dacb54
       options: --security-opt seccomp=unconfined
+
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -23,24 +23,33 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            registry.npmjs.org:443
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
+
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         name: Setup PNPM
         with:
           version: 10.11.1
+
       - name: Configure Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
+
       - name: Install dependencies on cache miss
         run: |
           pnpm install -g semantic-release semantic-release-export-data
         shell: bash
+
       - name: Get next release version
         id: get-next-version
         env:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -25,32 +25,33 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
 
-      - name: "Checkout code"
+      - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - name: "Run analysis"
+      - name: Run analysis
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - name: "Upload artifact"
+      - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.pre.node20
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - name: "Upload to code-scanning"
+      - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### TL;DR

Enhance GitHub Actions security by switching from audit to block mode in the Harden Runner step-security action.

### What changed?

- Changed `egress-policy` from `audit` to `block` in multiple workflow files:
  - `.github/workflows/audit.yaml`
  - `.github/workflows/ci.yaml`
  - `.github/workflows/dependency-review.yml`
  - `.github/workflows/get_next_version.yaml`
- Added explicit `allowed-endpoints` configurations to each workflow to permit only necessary network connections
- Improved formatting in workflow files with additional spacing between steps for better readability

### How to test?

1. Run the affected GitHub Actions workflows to verify they complete successfully
2. Confirm that the workflows can access their required endpoints
3. Verify that no unauthorized network connections are being made during workflow execution

### Why make this change?

This change improves the security posture of the CI/CD pipeline by implementing a zero-trust approach to network access. By switching from audit mode (which only logs unauthorized connections) to block mode (which actively prevents them), we reduce the attack surface and prevent potential supply chain attacks. The explicit allowlisting of required endpoints ensures workflows have only the minimum network access needed to function.