### PR TITLE
docs: correct the reuse.software URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: 0BSD
 ![crates.io package](https://img.shields.io/crates/v/charx.svg)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/release/AliSajid/charx)
 ![Crates.io](https://img.shields.io/crates/l/charx)
-[![REUSE status](https://api.reuse.software/badge/github.com/AliSajid/brainfoamkit)](https://api.reuse.software/info/github.com/AliSajid/brainfoamkit)
+[![REUSE status](https://api.reuse.software/badge/github.com/AliSajid/charx)](https://api.reuse.software/info/github.com/AliSajid/charx)
 ![Codecov](https://img.shields.io/codecov/c/github/AliSajid/charx)
 ![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fgithub.com%2FAliSajid%2Fcharx%2Fblob%2Fmain%2FOSSMETADATA)
 ![Crates.io MSRV](https://img.shields.io/crates/msrv/charx)


### PR DESCRIPTION
# Description

This pull request updates the REUSE compliance badge in the `README.md` file to correctly reference the `charx` repository instead of the unrelated `brainfoamkit` repository. This ensures that the badge accurately reflects the REUSE status for this project.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
