### PR TITLE
ci: add an escape hatch for the get-next-version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,7 @@ jobs:
   get_next_version:
     uses: ./.github/workflows/get_next_version.yaml
     needs: [ci, check_changed_dirs]
-    if: ${{ needs.ci.outputs.pull_request == "true" && needs.ci.outputs.result == 'success'}}
+    if: ${{ needs.ci.outputs.pull_request == 'true' && needs.ci.outputs.result == 'success'}}
     secrets: inherit # pragma: allowlist secret
     with:
       base_ref: ${{github.event.base_ref}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
     types:
       - closed
   workflow_dispatch:
@@ -162,8 +163,10 @@ jobs:
   get_next_version:
     uses: ./.github/workflows/get_next_version.yaml
     needs: [ci, check_changed_dirs]
-    if: ${{needs.ci.outputs.result == 'success'}}
+    if: ${{ github.event_name == "pull_request" && needs.ci.outputs.result == 'success'}}
     secrets: inherit # pragma: allowlist secret
+    with:
+      base_ref: ${{github.event.base_ref}}
   semantic-release:
     needs: [ci, get_next_version]
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,7 @@ jobs:
     if: ${{ needs.ci.outputs.pull_request == 'true' && needs.ci.outputs.result == 'success'}}
     secrets: inherit # pragma: allowlist secret
     with:
-      base_ref: ${{github.event.base_ref}}
+      base_ref: ${{github.base_ref}}
   semantic-release:
     needs: [ci, get_next_version]
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || github.event_name == 'workflow_dispatch'
     outputs:
       result: ${{steps.result.outputs.result}}
+      pull_request: ${{steps.result.outputs.pull_request}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,9 @@ jobs:
       - name: Set Result
         if: always()
         id: result
-        run: echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "result=${{job.status}}" >> "$GITHUB_OUTPUT"
+          echo "pull_request=${{github.event_name=='pull_request'}}" >> "$GITHUB_OUTPUT"
   generate_code_coverage:
     uses: ./.github/workflows/code_coverage.yaml
     needs: [ci, check_changed_dirs]
@@ -163,7 +165,7 @@ jobs:
   get_next_version:
     uses: ./.github/workflows/get_next_version.yaml
     needs: [ci, check_changed_dirs]
-    if: ${{ github.event_name == "pull_request" && needs.ci.outputs.result == 'success'}}
+    if: ${{ needs.ci.outputs.pull_request == "true" && needs.ci.outputs.result == 'success'}}
     secrets: inherit # pragma: allowlist secret
     with:
       base_ref: ${{github.event.base_ref}}

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -4,6 +4,10 @@
 name: Next version release check
 on:
   workflow_call:
+    inputs:
+      base_ref:
+        description: "The branch the PR is targeted to"
+        type: string
     outputs:
       new_release:
         description: "Whether or not a new release needs to be published"
@@ -37,5 +41,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Preflight checks for release
         id: new_release_check
-        run: mise run get-next-version ${{github.event.head_ref}}
+        run: mise run get-next-version ${{inputs.base_ref}}
         shell: bash

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -8,6 +8,7 @@ on:
       base_ref:
         description: "The branch the PR is targeted to"
         type: string
+        required: true
     outputs:
       new_release:
         description: "Whether or not a new release needs to be published"

--- a/.mise/tasks/get-next-version.sh
+++ b/.mise/tasks/get-next-version.sh
@@ -11,7 +11,8 @@ NEXT_VERSION=$(cog bump --auto --dry-run --skip-untracked)
 CALLING_BRANCH=$1
 
 if [ -z "$CALLING_BRANCH" ]; then
-    echo "No calling branch provided"
+    echo "Usage: $0 <calling-branch>" >&2
+    echo "No calling branch provided" >&2
     exit 1
 fi
 

--- a/.mise/tasks/get-next-version.sh
+++ b/.mise/tasks/get-next-version.sh
@@ -10,6 +10,10 @@
 NEXT_VERSION=$(cog bump --auto --dry-run --skip-untracked)
 CALLING_BRANCH=$1
 
+if [ -z "$CALLING_BRANCH" ]; then
+    exit 1
+fi
+
 case "$CALLING_BRANCH" in
 next)
     echo "called from 'next' branch"

--- a/.mise/tasks/get-next-version.sh
+++ b/.mise/tasks/get-next-version.sh
@@ -11,6 +11,7 @@ NEXT_VERSION=$(cog bump --auto --dry-run --skip-untracked)
 CALLING_BRANCH=$1
 
 if [ -z "$CALLING_BRANCH" ]; then
+    echo "No calling branch provided"
     exit 1
 fi
 


### PR DESCRIPTION
# Description



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
